### PR TITLE
fix: INFRA-1631 inline mirror workflow steps for public repo

### DIFF
--- a/.github/workflows/mirror-to-azdo.yml
+++ b/.github/workflows/mirror-to-azdo.yml
@@ -6,14 +6,38 @@ on:
     tags: ['**']
   delete:
 
+concurrency:
+  group: mirror-${{ github.event.repository.name }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   mirror:
-    uses: Ferlab-Ste-Justine/qlin-azure-devops/.github/workflows/azdo-mirror.yml@main
-    with:
-      repo_name: ${{ github.event.repository.name }}
-      event_name: ${{ github.event_name }}
-      ref: ${{ github.ref }}
-      ref_type: ${{ github.ref_type }}
-      event_ref: ${{ github.event.ref }}
-    secrets:
-      AZDO_SSH_KEY: ${{ secrets.AZDO_SSH_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$AZDO_SSH_KEY" > ~/.ssh/azdo_key
+          chmod 600 ~/.ssh/azdo_key
+          printf '%s\n' "ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H" >> ~/.ssh/known_hosts
+        env:
+          AZDO_SSH_KEY: ${{ secrets.AZDO_SSH_KEY }}
+
+      - name: Mirror to Azure DevOps
+        run: |
+          git remote add azdo "git@ssh.dev.azure.com:v3/Ferlabcrsj/Qlin/${{ github.event.repository.name }}"
+
+          if [ "${{ github.event_name }}" = "delete" ]; then
+            git push azdo --delete "${{ github.event.ref }}"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            git push azdo "${{ github.ref }}:${{ github.ref }}" --force
+          else
+            BRANCH="${{ github.ref }}"
+            git push azdo "refs/remotes/origin/${BRANCH#refs/heads/}:${BRANCH}" --force
+          fi
+        env:
+          GIT_SSH_COMMAND: "ssh -i ~/.ssh/azdo_key"


### PR DESCRIPTION
Public repos cannot call reusable workflows from private repos on GitHub Actions. Inline the steps from azdo-mirror.yml directly.